### PR TITLE
fix(config): trim host values from env and flag parsing

### DIFF
--- a/apps/server/internal/config/config.go
+++ b/apps/server/internal/config/config.go
@@ -41,7 +41,7 @@ func ParseRunConfig(argv []string, env map[string]string, cwd string) (RuntimeCo
 		args = args[1:]
 	}
 
-	host := getOrDefault(env["WOOTTY_HOST"], DefaultHost)
+	host := normalizeHost(env["WOOTTY_HOST"], DefaultHost)
 	port := parsePositiveInt(env["WOOTTY_PORT"], DefaultPort)
 	if strings.TrimSpace(env["WOOTTY_RECONNECT_GRACE_MS"]) != "" {
 		return RuntimeConfig{}, errors.New(
@@ -70,7 +70,7 @@ func ParseRunConfig(argv []string, env map[string]string, cwd string) (RuntimeCo
 		case "--host":
 			i++
 			if i < len(args) && strings.TrimSpace(args[i]) != "" {
-				host = args[i]
+				host = strings.TrimSpace(args[i])
 			}
 			continue
 		case "--detached-ttl-ms":
@@ -342,6 +342,14 @@ func getOrDefault(value string, fallback string) string {
 		return fallback
 	}
 	return value
+}
+
+func normalizeHost(value string, fallback string) string {
+	trimmed := strings.TrimSpace(value)
+	if trimmed == "" {
+		return fallback
+	}
+	return trimmed
 }
 
 func parseCSVList(value string) []string {

--- a/apps/server/internal/config/config_test.go
+++ b/apps/server/internal/config/config_test.go
@@ -92,6 +92,34 @@ func TestParseRunConfigParsesAllowedOrigins(t *testing.T) {
 	}
 }
 
+func TestParseRunConfigTrimsHostFromEnvironment(t *testing.T) {
+	cfg, err := ParseRunConfig(
+		[]string{"run"},
+		map[string]string{"WOOTTY_HOST": " 127.0.0.1 "},
+		"/tmp/wootty/apps/server",
+	)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if cfg.Host != "127.0.0.1" {
+		t.Fatalf("expected trimmed host from env, got %q", cfg.Host)
+	}
+}
+
+func TestParseRunConfigTrimsHostFromFlag(t *testing.T) {
+	cfg, err := ParseRunConfig(
+		[]string{"run", "--host", " 127.0.0.1 "},
+		map[string]string{},
+		"/tmp/wootty/apps/server",
+	)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if cfg.Host != "127.0.0.1" {
+		t.Fatalf("expected trimmed host from flag, got %q", cfg.Host)
+	}
+}
+
 func TestParseRunConfigUnknownFlag(t *testing.T) {
 	_, err := ParseRunConfig([]string{"run", "--nope"}, map[string]string{}, "/tmp/wootty/apps/server")
 	if err == nil {


### PR DESCRIPTION
### Motivation
- Host values provided via environment or CLI flags could retain leading/trailing whitespace which leads to exact-string mismatches when binding or matching origins. 
- Normalizing host input prevents subtle runtime errors when comparing `RuntimeConfig.Host` against request origins or bind addresses. 
- Add regression coverage to ensure host trimming behavior remains stable.

### Description
- Trim `WOOTTY_HOST` by introducing `normalizeHost` and use it when constructing `RuntimeConfig` instead of accepting raw env values. 
- Trim the `--host` flag argument during CLI parsing before assigning to the runtime configuration. 
- Add tests `TestParseRunConfigTrimsHostFromEnvironment` and `TestParseRunConfigTrimsHostFromFlag` to `apps/server/internal/config/config_test.go` to cover both env and flag cases. 
- Files changed: `apps/server/internal/config/config.go` and `apps/server/internal/config/config_test.go`.

### Testing
- Ran the repository JS unit suite with `pnpm test` (Vitest) and the web tests completed successfully (note: environment Node version warning was observed). 
- Ran Go unit tests for the server with `cd apps/server && go test ./internal/config ./internal/server` and they passed. 
- New config tests specifically for host trimming executed and succeeded as part of the Go test run.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a522aba38c832a8e0e2ca377d688cf)